### PR TITLE
Fix compilation and linking errors with GCC 8.3

### DIFF
--- a/src/corecmd/CMakeLists.txt
+++ b/src/corecmd/CMakeLists.txt
@@ -29,6 +29,10 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
     CXX_STANDARD_REQUIRED ON
 )
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_link_libraries(${PROJECT_NAME} PRIVATE stdc++fs)
+endif()
+
 if(WIN32)
     target_link_libraries(${PROJECT_NAME} PRIVATE shlwapi)
     target_compile_definitions(${PROJECT_NAME} PRIVATE _CRT_SECURE_NO_WARNINGS)

--- a/src/corecmd/main.cpp
+++ b/src/corecmd/main.cpp
@@ -50,6 +50,10 @@ using TStringSet = std::set<TString>;
 #endif
 
 // ---------------------------------------- Functions ----------------------------------------
+static inline bool starts_with(const std::string &str, const std::string &prefix) {
+    return str.size() >= prefix.size() && 
+           str.compare(0, prefix.size(), prefix) == 0;
+}
 
 static inline std::string tstr2str(const TString &str) {
 #ifdef _WIN32
@@ -169,7 +173,7 @@ static void copyDirectory(const fs::path &srcRootDir, const fs::path &srcDir,
 
             // Copy if symlink points inside the source directory
             copyFile(entryPath, destDir,
-                     linkPath.string().starts_with(srcRootDir.string())
+                     starts_with(linkPath.string(), srcRootDir.string())
                          ? fs::relative(linkPath, fs::canonical(entryPath.parent_path())).string()
                          : std::string(),
                      force, verbose);


### PR DESCRIPTION
考虑国内主流信创Linux 平台自带的GCC 还在使用gcc 8.3，所以从代码上兼容到gcc8.3的编译链接。