### PR TITLE
InstallPackage.cmake: Bugfix: Append GENERATOR_PLATFORM to _extra_args

### DIFF
--- a/cmake/modules/private/InstallPackage.cmake
+++ b/cmake/modules/private/InstallPackage.cmake
@@ -85,7 +85,7 @@ function(qm_install_package _name)
         endif()
 
         if(CMAKE_GENERATOR_PLATFORM)
-            set(_extra_args ${_extra_args} -A "${CMAKE_GENERATOR_PLATFORM}")
+            list(APPEND _extra_args -A "${CMAKE_GENERATOR_PLATFORM}")
         endif()
 
         # Remove old build directory

--- a/cmake/modules/private/InstallPackage.cmake
+++ b/cmake/modules/private/InstallPackage.cmake
@@ -85,7 +85,7 @@ function(qm_install_package _name)
         endif()
 
         if(CMAKE_GENERATOR_PLATFORM)
-            set(_extra_args -A "${CMAKE_GENERATOR_PLATFORM}")
+            set(_extra_args ${_extra_args} -A "${CMAKE_GENERATOR_PLATFORM}")
         endif()
 
         # Remove old build directory


### PR DESCRIPTION
Hello,

I've fixed a problem, that was happening on a Windows-PC, where CMake/ninja might be misconfigured. We are using qwindowkit in a project using the CMake 'Visual Studio 17 2022' Generator on x64. We want to build a static library of qwindowkit while building our project.

While building qwindowkit you install qmsetup. Configuring qmsetup failed on one PC with the following qmsetup_configure.log:
```
-- Building for: Ninja
CMake Error at CMakeLists.txt:3 (project):
  Generator

     Ninja

  does not support platform specification, but platform

     x64

  was specified.
```

So, apparantly, only passing -A x64 to Cmake made it use the ninja Generator for whatever reason, which failed, because this specific ninja doesn't support x64 platforms. The rest of the project is built using Visual Studio 2022 and CMAKE_GENERATOR is set to Visual Studio.

So, I've changed InstallPackage.cmake to append the -A parameter to extra_args, so the configuring step will always pass the Generator if the Variable is set. This way it shouldn't be possible to fall into a different generator, when CMAKE_GENERATOR_PLATFORM is present.